### PR TITLE
Missing migration from sites

### DIFF
--- a/project/asylum/contrib/sites/migrations/0003_auto_20151129_2000.py
+++ b/project/asylum/contrib/sites/migrations/0003_auto_20151129_2000.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.sites.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0002_set_site_domain_and_name'),
+    ]
+
+    operations = [
+        migrations.AlterModelManagers(
+            name='site',
+            managers=[
+                ('objects', django.contrib.sites.models.SiteManager()),
+            ],
+        ),
+    ]


### PR DESCRIPTION
Apparently some dependency changes this at some point
and we're left unable to run migrations before we run
makemigrations again...