### PR TITLE
Fix overwriting user .env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN . ../asylum-venv/bin/activate && pip install -r requirements/local.txt
 
 # Configure application
 USER root
-COPY project /opt/asylum/
 RUN echo "DATABASE_URL=postgres://asylum:asylum@localhost/asylum" > .env
+COPY project /opt/asylum/
 RUN chown -R asylum:asylum /opt/asylum/
 
 # Test npm (this will happen again at entrypoint)


### PR DESCRIPTION
Creates .env automatically before copying the project. That way default .env gets overwritten by user .env. Fixes #71 