### PR TITLE
Locale fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ COPY project /opt/asylum/
 RUN echo "DATABASE_URL=postgres://asylum:asylum@localhost/asylum" > .env
 RUN chown -R asylum:asylum /opt/asylum/
 
+# Build localisations
+USER asylum
+RUN . ../asylum-venv/bin/activate && \
+    for app in locale */locale; do (cd $(dirname $app) && ../manage.py compilemessages ); done
+
 # Test npm (this will happen again at entrypoint)
 USER asylum
 RUN npm run build

--- a/project/access/locale/fi/LC_MESSAGES/django.po
+++ b/project/access/locale/fi/LC_MESSAGES/django.po
@@ -1,0 +1,90 @@
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-29 03:10+0200\n"
+"PO-Revision-Date: 2015-11-29 03:10+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#: access/models.py:9 access/models.py:22 access/models.py:41
+msgid "Label"
+msgstr "Nimiö"
+
+#: access/models.py:15
+msgid "Token Type"
+msgstr "Poletin tyyppi"
+
+#: access/models.py:16
+msgid "Token Types"
+msgstr "Poletin tyypit"
+
+#: access/models.py:23 access/models.py:56
+msgid "Member"
+msgstr "Jäsen"
+
+#: access/models.py:24
+msgid "Token type"
+msgstr "Tunnisteen tyyppi"
+
+#: access/models.py:25
+msgid "Token value"
+msgstr "Tunnisteen arvo"
+
+#: access/models.py:26
+msgid "Revoked"
+msgstr "Peruutettu"
+
+#: access/models.py:31
+#, python-format
+msgid "%s '%s' for %s"
+msgstr ""
+
+#: access/models.py:34
+msgid "Token"
+msgstr "Poletti"
+
+#: access/models.py:35
+msgid "Tokens"
+msgstr "Poletit"
+
+#: access/models.py:42
+msgid "Bit number"
+msgstr "Bittinumero"
+
+#: access/models.py:43
+msgid "External identifier"
+msgstr "Ulkoinen tunnus"
+
+#: access/models.py:49
+msgid "Access Type"
+msgstr "Pääsyoikeuden tyyppi"
+
+#: access/models.py:50
+msgid "Access Types"
+msgstr "Pääsyoikeuden tyypit"
+
+#: access/models.py:57
+msgid "Access"
+msgstr "Pääsyoikeus"
+
+#: access/models.py:60
+#, python-format
+msgid "%s for %s"
+msgstr ""
+
+#: access/models.py:63
+msgid "Grant"
+msgstr "Pääsyoikeus"
+
+#: access/models.py:64
+msgid "Grants"
+msgstr "Pääsyoikeudet"

--- a/project/access/models.py
+++ b/project/access/models.py
@@ -11,6 +11,10 @@ class TokenType(AtomicVersionMixin, CleanSaveMixin, models.Model):
     def __str__(self):
         return self.label
 
+    class Meta:
+        verbose_name = _('Token Type')
+        verbose_name_plural = _('Token Types')
+
 revisions.default_revision_manager.register(TokenType)
 
 
@@ -26,6 +30,10 @@ class Token(AtomicVersionMixin, CleanSaveMixin, models.Model):
             return self.label
         return _("%s '%s' for %s") % (self.ttype, self.value, self.owner)
 
+    class Meta:
+        verbose_name = _('Token')
+        verbose_name_plural = _('Tokens')
+
 revisions.default_revision_manager.register(Token)
 
 
@@ -37,6 +45,10 @@ class AccessType(AtomicVersionMixin, CleanSaveMixin, models.Model):
     def __str__(self):
         return self.label
 
+    class Meta:
+        verbose_name = _('Access Type')
+        verbose_name_plural = _('Access Types')
+
 revisions.default_revision_manager.register(AccessType)
 
 
@@ -46,5 +58,9 @@ class Grant(AtomicVersionMixin, CleanSaveMixin, models.Model):
 
     def __str__(self):
         return _("%s for %s") % (self.atype, self.owner)
+
+    class Meta:
+        verbose_name = _('Grant')
+        verbose_name_plural = _('Grants')
 
 revisions.default_revision_manager.register(Grant)

--- a/project/config/settings/common.py
+++ b/project/config/settings/common.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 MIDDLEWARE_CLASSES = (
     # Make sure djangosecure.middleware.SecurityMiddleware is listed first
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/project/creditor/locale/fi/LC_MESSAGES/django.po
+++ b/project/creditor/locale/fi/LC_MESSAGES/django.po
@@ -1,0 +1,95 @@
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-29 03:10+0200\n"
+"PO-Revision-Date: 2015-11-29 03:01+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#: creditor/models.py:12 creditor/models.py:65
+msgid "Label"
+msgstr "Nimiö"
+
+#: creditor/models.py:18
+msgid "Transaction Tag"
+msgstr "Tapahtuman tägi"
+
+#: creditor/models.py:19
+msgid "Transaction Tags"
+msgstr "Tapahtuman tägit"
+
+#: creditor/models.py:33
+msgid "Datetime"
+msgstr "Aika"
+
+#: creditor/models.py:34 creditor/models.py:67
+msgid "Tag"
+msgstr "Tägi"
+
+#: creditor/models.py:35
+msgid "Reference"
+msgstr "Viite"
+
+#: creditor/models.py:36 creditor/models.py:68
+msgid "Member"
+msgstr "Jäsen"
+
+#: creditor/models.py:37 creditor/models.py:69
+msgid "Amount"
+msgstr "Määrä"
+
+#: creditor/models.py:38
+msgid "Unique transaction id"
+msgstr "Transaktion yksilöllinen tunniste"
+
+#: creditor/models.py:42
+#, python-format
+msgid "%+.2f for %s (%s)"
+msgstr ""
+
+#: creditor/models.py:43
+#, python-format
+msgid "%+.2f for %s"
+msgstr ""
+
+#: creditor/models.py:46
+msgid "Transaction"
+msgstr "Tapahtuma"
+
+#: creditor/models.py:47
+msgid "Transactions"
+msgstr "Tapahtumat"
+
+#: creditor/models.py:56 creditor/models.py:61
+msgid "Monthly"
+msgstr "Kuukausittain"
+
+#: creditor/models.py:57 creditor/models.py:62
+msgid "Yearly"
+msgstr "Vuosittain"
+
+#: creditor/models.py:66
+msgid "Recurrence type"
+msgstr "Toistuvuuden tyyppi"
+
+#: creditor/models.py:74
+#, python-format
+msgid "%+.2f %s for %s (%s)"
+msgstr ""
+
+#: creditor/models.py:124
+msgid "Recurring Transaction"
+msgstr "Toistuva tapahtuma"
+
+#: creditor/models.py:125
+msgid "Recurring Transactions"
+msgstr "Toistuvat tapahtumat"

--- a/project/creditor/models.py
+++ b/project/creditor/models.py
@@ -14,6 +14,10 @@ class TransactionTag(AtomicVersionMixin, CleanSaveMixin, models.Model):
     def __str__(self):
         return self.label
 
+    class Meta:
+        verbose_name = _('Transaction Tag')
+        verbose_name_plural = _('Transaction Tags')
+
 revisions.default_revision_manager.register(TransactionTag)
 
 
@@ -37,6 +41,10 @@ class Transaction(AtomicVersionMixin, CleanSaveMixin, models.Model):
         if self.tag:
             return _("%+.2f for %s (%s)") % (self.amount, self.owner, self.tag)
         return _("%+.2f for %s") % (self.amount, self.owner)
+
+    class Meta:
+        verbose_name = _('Transaction')
+        verbose_name_plural = _('Transactions')
 
 revisions.default_revision_manager.register(Transaction)
 
@@ -111,5 +119,9 @@ class RecurringTransaction(AtomicVersionMixin, CleanSaveMixin, models.Model):
         t.amount = self.amount
         t.save()
         return True
+
+    class Meta:
+        verbose_name = _('Recurring Transaction')
+        verbose_name_plural = _('Recurring Transactions')
 
 revisions.default_revision_manager.register(RecurringTransaction)

--- a/project/members/locale/fi/LC_MESSAGES/django.po
+++ b/project/members/locale/fi/LC_MESSAGES/django.po
@@ -1,0 +1,118 @@
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-29 03:10+0200\n"
+"PO-Revision-Date: 2015-11-29 02:53+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.6\n"
+
+#: members/forms.py:7
+#, python-format
+msgid "I have read and accept <a href='%s' target='_blank'>the rules</a>"
+msgstr "Olen lukenut ja hyväksyn <a href=‘%s’ target=‘_blank’>säännöt</a>"
+
+#: members/models.py:31
+msgid "First name"
+msgstr "Etunimi"
+
+#: members/models.py:32
+msgid "Last name"
+msgstr "Sukunimi"
+
+#: members/models.py:33
+msgid "City of residence"
+msgstr "Paikkakunta"
+
+#: members/models.py:34
+msgid "Email address"
+msgstr "Sähköpostiosoite"
+
+#: members/models.py:35
+msgid "Phone number"
+msgstr "Puhelinnumero"
+
+#: members/models.py:36
+msgid "Nickname"
+msgstr "Lempinimi"
+
+#: members/models.py:46 members/models.py:78
+msgid "Label"
+msgstr "Nimiö"
+
+#: members/models.py:52
+msgid "Member Type"
+msgstr "Jäsentyyppi"
+
+#: members/models.py:53
+msgid "Member Types"
+msgstr "Jäsentyypit"
+
+#: members/models.py:59
+msgid "Date accepted"
+msgstr "Hyväksymispäivä"
+
+#: members/models.py:60
+msgid "Membership types"
+msgstr "Jäsentyyppi"
+
+#: members/models.py:61
+msgid "Anonymized id (for use in external databases)"
+msgstr "Anonymisoitu tunniste (käytettäväksi ulkoisissa tietokannoissa)"
+
+#: members/models.py:62
+msgid "Member id no"
+msgstr "Jäsennumero"
+
+#: members/models.py:72
+msgid "Member"
+msgstr "Jäsen"
+
+#: members/models.py:73
+msgid "Members"
+msgstr "Jäsenet"
+
+#: members/models.py:84
+msgid "Membership Application Tag"
+msgstr "Jäsenhakemuksen tägi"
+
+#: members/models.py:85
+msgid "Membership Application Tags"
+msgstr "Jäsenhakemuksen tägit"
+
+#: members/models.py:90
+msgid "Application tags"
+msgstr ""
+
+#: members/models.py:108
+msgid "Membership Application"
+msgstr "Jäsenhakemus"
+
+#: members/models.py:109
+msgid "Membership Applications"
+msgstr "Jäsenhakemukset"
+
+#: members/templates/members/application_form.html:4
+#: members/templates/members/application_form.html:5
+msgid "Apply for membership"
+msgstr "Hae jäseneksi"
+
+#: members/templates/members/application_received.html:4
+msgid "Received. Thank you"
+msgstr "Jäsenhakemuksesi on vastaanotettu. Paljon kiitoksia!"
+
+#: members/templates/members/application_received.html:5
+msgid "Application received. Thank you"
+msgstr "Jäsenhakemuksesi on vastaanotettu. Paljon kiitoksia!"
+
+#: members/templates/members/application_received.html:9
+msgid "We'll get back to you"
+msgstr "Vastaamme sinulle pian."

--- a/project/members/models.py
+++ b/project/members/models.py
@@ -50,6 +50,10 @@ class MemberType(AtomicVersionMixin, CleanSaveMixin, models.Model):
     def __str__(self):
         return self.label
 
+    class Meta:
+        verbose_name = _('Member Type')
+        verbose_name_plural = _('Member Types')
+
 revisions.default_revision_manager.register(MemberType)
 
 
@@ -70,6 +74,9 @@ class Member(MemberCommon):
     def save(self, *args, **kwargs):
         return super().save(*args, **kwargs)
 
+class Meta:
+        verbose_name = _('Member')
+        verbose_name_plural = _('Members')
 revisions.default_revision_manager.register(Member)
 
 class MembershipApplicationTag(AtomicVersionMixin, CleanSaveMixin, models.Model):
@@ -77,6 +84,10 @@ class MembershipApplicationTag(AtomicVersionMixin, CleanSaveMixin, models.Model)
 
     def __str__(self):
         return self.label
+
+    class Meta:
+        verbose_name = _('Membership Application Tag')
+        verbose_name_plural = _('Membership Application Tags')
 
 
 class MembershipApplication(MemberCommon):
@@ -114,5 +125,9 @@ class MembershipApplication(MemberCommon):
             if h:
                 h.on_approved(self, m)
             self.delete()
+
+    class Meta:
+        verbose_name = _('Membership Application')
+        verbose_name_plural = _('Membership Applications')
 
 revisions.default_revision_manager.register(MembershipApplication)


### PR DESCRIPTION
Locales are now detected by browser preference and merge conflict @d7a012b is fixed. Revisioning has been tested. Maildump at :1080 can be reached via http. English locales *should not* be needed, as django defaults to original messages if appropriate locale is not found. I.E. "No locale English found, falling back to internal strings in English".

*Should not*, as http://imgur.com/MU7QV3t (string about accepting rules). 

```
otso@thane:~/git/asylum$ grep -r "hyväksyn" ./project/* 

./project/members/locale/fi/LC_MESSAGES/django.po:msgstr "Olen lukenut ja
hyväksyn <a href=‘%s’ target=‘_blank’>säännöt</a>"

otso@thane:~/git/asylum$
```

Maybe there is a bug in the way form label at project/members/forms.py gets treated?
```
class ApplicationForm(forms.ModelForm):
    rules_accepted = forms.BooleanField(required=True, label=_("I have read and accept <a href='%s' target='_blank'>the rules</a>") % settings.APPLICATION_RULES_URL)
```