### PR TITLE
Add delay between starting SQL service and using it. Fixes #77

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get install -y nodejs
 # Create database
 USER postgres
 RUN service postgresql start && \
-    sleep 5 && \
     createuser asylum && \
     createdb -E utf-8 -T template0 -O asylum asylum && \
     psql -U postgres -d postgres -c "alter user asylum with password 'asylum';"
@@ -62,8 +61,8 @@ RUN npm run build
 # Run migrate and create admin user
 USER asylum
 RUN sudo -u postgres service postgresql start; \
-    sleep 5 && \
     . ../asylum-venv/bin/activate && \
+    export PGPASSWORD=asylum; while true; do psql -q asylum -c 'SELECT 1;' 1>/dev/null 2>&1 ; if [ "$?" -ne "0" ]; then echo "Waiting for psql"; sleep 1; else break; fi; done && \
     ./manage.py migrate && \
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'nospamplz@hacklab.fi', 'admin')" | ./manage.py shell
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get install -y nodejs
 # Create database
 USER postgres
 RUN service postgresql start && \
+    sleep 5 && \
     createuser asylum && \
     createdb -E utf-8 -T template0 -O asylum asylum && \
     psql -U postgres -d postgres -c "alter user asylum with password 'asylum';"
@@ -61,6 +62,7 @@ RUN npm run build
 # Run migrate and create admin user
 USER asylum
 RUN sudo -u postgres service postgresql start; \
+    sleep 5 && \
     . ../asylum-venv/bin/activate && \
     ./manage.py migrate && \
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'nospamplz@hacklab.fi', 'admin')" | ./manage.py shell


### PR DESCRIPTION
Docker build crashes most of the time because of race condition in starting the SQL service and running commands on it. Adding a few seconds of delay is hackish, someone else might need 6 seconds after all. But it works for me :smile: 