### PR TITLE
use unicodeslugify for all our slug needs

### DIFF
--- a/project/config/settings/common.py
+++ b/project/config/settings/common.py
@@ -24,6 +24,10 @@ env = environ.Env()
 if os.path.isfile(str(ROOT_DIR + '.env')):
     environ.Env.read_env(str(ROOT_DIR + '.env'))
 
+# Monkeypatch djangos own slugify with Mozilla teams Unicode-aware one
+import slugify as unicodeslugify
+import django.template.defaultfilters
+django.template.defaultfilters.slugify = lambda x: unicodeslugify.slugify(x, only_ascii=True, lower=True, spaces=False)
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------
@@ -245,7 +249,7 @@ AUTHENTICATION_BACKENDS = (
 
 
 # SLUGLIFIER
-AUTOSLUG_SLUGIFY_FUNCTION = 'slugify.slugify'
+AUTOSLUG_SLUGIFY_FUNCTION = 'django.template.defaultfilters.slugify'
 
 # Location of root django.contrib.admin URL, use {% url 'admin:index' %}
 ADMIN_URL = r'^admin/'

--- a/project/members/tests/fixtures/memberlikes.py
+++ b/project/members/tests/fixtures/memberlikes.py
@@ -4,6 +4,7 @@ import os, codecs
 import random
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
+from django.template.defaultfilters import slugify
 import factory.django, factory.fuzzy
 from members.models import generate_unique_memberid, MemberType, MembershipApplicationTag
 from asylum.utils import get_random_objects
@@ -25,13 +26,13 @@ cities = ['Helsinki', 'Turku', 'Jyväskylä', 'Mikkeli', 'Pori', 'Kuopio', 'Tamp
 def generate_email(memberlike):
     try:
         addr = '%s.%s@hacklab.hax' % (
-            memberlike.fname.encode('ascii','ignore').decode('utf-8').lower(),
-            memberlike.lname.encode('ascii','ignore').decode('utf-8').lower()
+            slugify(memberlike.fname),
+            slugify(memberlike.lname)
         )
         validate_email(addr)
         return addr
     except ValidationError as e:
-        return 'member_%d@hacklab.hax' % generate_unique_memberid()
+        return 'member_%d_%d@hacklab.hax' % (generate_unique_memberid(), random.randint(10,2**16))
 
 
 class MemberlikeFactoryBase(factory.django.DjangoModelFactory):

--- a/project/requirements/base.txt
+++ b/project/requirements/base.txt
@@ -24,6 +24,7 @@ Pillow==3.0.0
 psycopg2==2.6.1
 
 # Unicode slugification
+git+git://github.com/mozilla/unicode-slugify#egg=unicode-slugify==0.1.3-HEAD
 django-autoslug==1.9.3
 
 # Time zones support


### PR DESCRIPTION
Makes for more sensible email addresses for the autogenerated memberlikes for example.