### PR TITLE
Add URL route required by DJDT.

### DIFF
--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -53,3 +53,10 @@ if settings.DEBUG:
         url(r'^404/$', default_views.page_not_found),
         url(r'^500/$', default_views.server_error),
     ]
+
+    # This is required by Django Debug Toolbar
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]
+


### PR DESCRIPTION
Currently all URLs are giving a NoReverseMatch exception caused by the Django Debug Toolbar when opened with a web browser on my development setup. Adding the required URL config mentioned in the [DJDT docs](https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#urlconf) seems to fix the issue.